### PR TITLE
requires ai bundle

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,4 +1,7 @@
 module.exports = {
+  requires: {
+    bundle: "ai"
+  },
   run: [
     // 1. Clone the repository
     {


### PR DESCRIPTION
The "bundle": "ai" clause is required for cuda, starting pinokio 5 (cuda is not the default dependency anymore, and any launcher that requires cuda build requires this)