### PR TITLE
fix port error on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1067,14 +1067,28 @@ if STATIC_DIR.exists():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="SongGeneration Studio API Server")
     parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", type=int, default=8000)
+    # Accept string so templating leftovers like "{{port}}" don't crash argparse
+    parser.add_argument("--port", type=str, default=None)
     args = parser.parse_args()
+
+    # Resolve port: prefer env PORT (set by Pinokio), then CLI, else default
+    port_raw = os.getenv("PORT") or args.port or "7860"
+
+    # Robust port parsing with sane fallback
+    try:
+        port = int(port_raw)
+    except (TypeError, ValueError):
+        port = 7860
+
+    if port < 1 or port > 65535:
+        print(f"[WARN] Invalid port '{port_raw}', falling back to 7860")
+        port = 7860
 
     print()
     print("=" * 60)
     print("  SongGeneration Studio")
-    print(f"  Open http://{args.host}:{args.port} in your browser")
+    print(f"  Open http://{args.host}:{port} in your browser")
     print("=" * 60)
     print()
 
-    uvicorn.run(app, host=args.host, port=args.port)
+    uvicorn.run(app, host=args.host, port=port)

--- a/start.js
+++ b/start.js
@@ -11,10 +11,13 @@ module.exports = {
         env: {
           // Use platform-specific path separator: semicolon for Windows, colon for Unix
           PYTHONPATH: "{{platform === 'win32' ? cwd + '/app;' + cwd + '/app/codeclm/tokenizer/Flow1dVAE' : cwd + '/app:' + cwd + '/app/codeclm/tokenizer/Flow1dVAE'}}",
-          PYTHONUTF8: "1"
+          PYTHONUTF8: "1",
+          // Pinokio fills PORT; main.py will fallback internally if empty
+          PORT: "{{port}}"
         },
         path: "app",
-        message: "python main.py --host 127.0.0.1 --port {{port}}",
+        // Let main.py resolve the port from env or its own default to avoid CLI parse issues
+        message: "python main.py --host 127.0.0.1",
         on: [{
           event: "/http:\\/\\/[^\\s\\/]+:\\d{2,5}(?=[^\\w]|$)/",
           done: true


### PR DESCRIPTION
I submitted this PR to unblock the error, but it doesn’t really solve the underlying issue between Pinokio’s port and its execution. However, if the value is empty, it now defaults to 7860 so it doesn’t get blocked and can run properly.

It’s a quick hotfix to unblock Pinokio’s execution when using Codex.

related issue:
https://github.com/BazedFrog/SongGeneration-Studio/issues/23